### PR TITLE
Fix typo in adjustMods handling

### DIFF
--- a/src/factorioModRuntime.ts
+++ b/src/factorioModRuntime.ts
@@ -305,7 +305,7 @@ export class FactorioModRuntime extends EventEmitter {
 							});
 
 							for (const mod in args.adjustMods) {
-								if (args.adjustMods.hasOwnProperty(mod) && foundmods[mod])
+								if (args.adjustMods.hasOwnProperty(mod) && !foundmods[mod])
 								{
 									const adjust = args.adjustMods[mod];
 									if (adjust === true || adjust === false) {


### PR DESCRIPTION
If an adjustMods entry is already in mod-list.json then it duplicate the entry, if there wasn't it did nothing.
Now for each adjustMods entry, it create an entry only if it didn't exist, otherwise it will modify the existing entry