### PR TITLE
Removed base mod dependency

### DIFF
--- a/mod/info.json
+++ b/mod/info.json
@@ -7,5 +7,5 @@
     "homepage": "",
     "contact": "",
     "description": "An implementation of Debug Adapter Protocol for mods. For use with the associated vscode extension. This is a developer tool, not meant for actual gameplay. It is intentionally desync unsafe. Do not use it in multiplayer.",
-    "dependencies": ["base", "!coverage", "!profiler"]
+    "dependencies": ["!coverage", "!profiler"]
   }

--- a/mod/log.lua
+++ b/mod/log.lua
@@ -37,7 +37,12 @@ __DebugAdapter.stepIgnore(newlog)
 
 -- log protection is disabled in Instrument Mode on Factorio >= 0.18.34
 if __DebugAdapter.instrument then
-  local a,b,c = (mods or script.active_mods).base:match("(%d+).(%d+).(%d+)")
+  local base_version = (mods or script.active_mods).base
+  if not base_version then
+    log = newlog
+    return
+  end  
+  local a,b,c = base_version:match("(%d+).(%d+).(%d+)")
   if (a=="1" or (a=="0" and b=="18" and (tonumber(c) or 0)>=34)) then
     log = newlog
     return


### PR DESCRIPTION
Makes debugging https://github.com/Bilka2/minimal-no-base-mod work :)

Without this, the allowDisableBaseMod config option would also be a bit silly.