### PR TITLE
Change concept concepts to aliases of `any`

### DIFF
--- a/src/apidocs/ApiDocGenerator.ts
+++ b/src/apidocs/ApiDocGenerator.ts
@@ -569,7 +569,7 @@ export class ApiDocGenerator {
 					break;
 				case "concept":
 					output.write(this.convert_emmylua_description(this.format_entire_description(concept,this.view_documentation(concept.name))));
-					output.write(`---@class ${concept.name}\n\n`);
+					output.write(`---@alias ${concept.name} any\n\n`);
 					break;
 				case "struct":
 					this.add_emmylua_class(output, concept, true);


### PR DESCRIPTION
Prevents undefined field warnings when using any of the conepts in the `concept` category, since they only have a description. Descriptions do appear to work with aliases.

There are some special ones that could have more descriptive aliases or classes, however that would just be hardcoding api docs into the generator which is just wrong. The `table_or_array` concepts already get a bit of that by assuming that all their fields have the same type. Speaking of which, those could also use aliases (now?), however I don't have the neccessary TypeScript skills to properly implement that. And actually using aliases for it would be _even more hacky_ than the current implementation already is.
I'm talking about this for the record:
https://github.com/justarandomgeek/vscode-factoriomod-debug/blob/cf2b6dbb97e1310310c471fcfddaab2ee6b404ad/src/apidocs/ApiDocGenerator.ts#L65-L68
https://github.com/justarandomgeek/vscode-factoriomod-debug/blob/cf2b6dbb97e1310310c471fcfddaab2ee6b404ad/src/apidocs/ApiDocGenerator.ts#L808-L818