### PR TITLE
Workspace doc and readme improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -643,7 +643,7 @@
               },
               "factorioPath": {
                 "type": "string",
-                "description": "Path to Factorio binary.",
+                "description": "Path to Factorio binary file.",
                 "examples": [
                   "C:/Program Files (x86)/Steam/steamapps/common/Factorio/bin/x64/factorio.exe",
                   "C:/Program Files/Factorio/bin/x64/factorio.exe",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # VS Code Factorio Mod Debug
 
-This is a debug adapter for developing Factorio mods. It supports breakpoints, stepping, variable access, and the debug console. TODO Bilka: mention packaging and emmylua stuff here?
+This is a debug adapter for developing Factorio mods. It supports breakpoints, stepping, variable access, and the debug console. Furthermore, this extension offers profiling, packaging and publishing supports for Factorio mods. It also enhances/implements language server features for various Factorio mod file formats, including Factorio API Typedefs for [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua).
 
 ## Using Factorio Mod Debug
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # VS Code Factorio Mod Debug
 
-This is a debug adapter for developing Factorio mods. It supports breakpoints, stepping, variable access, and the debug console.
+This is a debug adapter for developing Factorio mods. It supports breakpoints, stepping, variable access, and the debug console. TODO Bilka: mention packaging and emmylua stuff here?
 
 ## Using Factorio Mod Debug
 
@@ -43,6 +43,12 @@ The profiler also provides a remote inteface `profiler` with the following funct
   * `dump()` - dump all timers immediately
   * `slow()` - return to slow-start mode (dumping on return from every event temporarily)
   * `save(name)` - return to slow-start mode and trigger an autosave with the given name. Defaults to "profiler" if unspecified.
+
+## Factorio API autocompletion
+
+You can generate EmmyLua docs for the Factorio API with the `Factorio: Generate Typedefs` command. Together with the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) language server, this enables autocompletion and other language server features for the Factorio API.
+
+To use `Factorio: Generate Typedefs`, press `Ctrl-Shift-P` to open the command palette and run the `Factorio: Generate Typedefs` command from there. In the file picker, open `factorio/doc-html/runtime-api.json`, and save the generated Lua file wherever you like. This will also offer to add it to the sumneko library files and adjust other configuration for [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua).
 
 ## Automatic Mod Packaging and Publishing
 

--- a/workspace.md
+++ b/workspace.md
@@ -11,6 +11,7 @@ I open the Factorio `mods` directory as the root of my workspace in VSCode, and 
       * `launch.json`
       * `settings.json`
       * `lua/plugin.lua`
+      * `runtime-api.lua`
     * `modname/`
       * `.git/...`
       * `info.json`
@@ -26,16 +27,20 @@ I open the Factorio `mods` directory as the root of my workspace in VSCode, and 
 I use [VScode](https://code.visualstudio.com/) (imagine that!), but it needs a few extensions to really shine in this context:
 
  * [Factorio Mod Debugger](https://marketplace.visualstudio.com/items?itemName=justarandomgeek.factoriomod-debug) - You are here
- * ~~[Factorio Lua API autocomplete](https://marketplace.visualstudio.com/items?itemName=svizzini.factorio-lua-api-autocomplete)~~ This has not been updated in some time and is no longer needed, as this functionality is now provided through the Language Server below.
- * A Lua Language server. There's like 30 of these, but the one I like is [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua)
+ * A Lua language server. I like to use [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua), the Factorio Mod Debugger has some extended support for it.
  * [Zip File Explorer](https://marketplace.visualstudio.com/items?itemName=slevesque.vscode-zipexplorer). Enables viewing files inside zips, which allows breakpoints/stepping inside them as well.
  * Optional: [indent-rainbow](https://marketplace.visualstudio.com/items?itemName=oderwat.indent-rainbow)
  * Optional: [Git Graph](https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph). I happen to like the graph git log view this extension gives as a place to do manual git operations more complicated than the builtin SCM view provides for.
 
-To generate EmmyLua docs for the Factorio API from the JSON docs press `Ctrl-Shift-P` to open the command palette and run the `Factorio: Generate Typedefs` command. Open `factorio/doc-html/runtime-api.json`, and save the generated lua file wherever you like. This will also offer to add it to the library and adjust other configuration for [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua).
+To provide Factorio Lua API autocompletion, the Factorio mod debugger extension generates EmmyLua docs from the Factorio JSON docs, which are then used by the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) language server for its autocompletion feature.
+To generate EmmyLua docs for the Factorio API from the JSON docs, press `Ctrl-Shift-P` to open the command palette and run the `Factorio: Generate Typedefs` command. In the file picker, open `factorio/doc-html/runtime-api.json`, and save the generated Lua file in the `.vscode` folder. This command will also offer to add it to the library and adjust other configuration for [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua). If you don't take this offer, you will have to add the generated Lua file to your `settings.json` manually: Add `"Lua.workspace.library": [ "path/to/mods/.vscode/runtime-api.lua" ]` to your settings.json.
+
+TODO Bilka: mention general manual settings.json setup for sumneko? Or if not, at least mention adding Factorio/data to the workspace libraries? (may only work well when using jans plugin?)
+
+TODO Bilka: An example launch.json may be nice, or mention the Using Factorio Mod Debug section. I found the example that was on discord really useful starting out, since using the intellisense and editor features to generate things was very new to me. Like, what does the Factorio path need to point to etc.
 
 
-Install [the Factorio Sumneko Lua Plugin](https://github.com/JanSharp/FactorioSumnekoLuaPlugin) into `.vscode/lua` to improve handling of `require`s, `global`, and `remote.call`.
+Install [the Factorio Sumneko Lua Plugin](https://github.com/JanSharp/FactorioSumnekoLuaPlugin) into `.vscode/lua` to improve handling of `require`s, `global`, `on_event` and `remote.call`.
 
 
 

--- a/workspace.md
+++ b/workspace.md
@@ -35,13 +35,9 @@ I use [VScode](https://code.visualstudio.com/) (imagine that!), but it needs a f
 To provide Factorio Lua API autocompletion, the Factorio mod debugger extension generates EmmyLua docs from the Factorio JSON docs, which are then used by the [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) language server for its autocompletion feature.
 To generate EmmyLua docs for the Factorio API from the JSON docs, press `Ctrl-Shift-P` to open the command palette and run the `Factorio: Generate Typedefs` command. In the file picker, open `factorio/doc-html/runtime-api.json`, and save the generated Lua file in the `.vscode` folder. This command will also offer to add it to the library and adjust other configuration for [sumneko.lua](https://marketplace.visualstudio.com/items?itemName=sumneko.lua). If you don't take this offer, you will have to add the generated Lua file to your `settings.json` manually: Add `"Lua.workspace.library": [ "path/to/mods/.vscode/runtime-api.lua" ]` to your settings.json.
 
-TODO Bilka: mention general manual settings.json setup for sumneko? Or if not, at least mention adding Factorio/data to the workspace libraries? (may only work well when using jans plugin?)
-
-TODO Bilka: An example launch.json may be nice, or mention the Using Factorio Mod Debug section. I found the example that was on discord really useful starting out, since using the intellisense and editor features to generate things was very new to me. Like, what does the Factorio path need to point to etc.
-
-
 Install [the Factorio Sumneko Lua Plugin](https://github.com/JanSharp/FactorioSumnekoLuaPlugin) into `.vscode/lua` to improve handling of `require`s, `global`, `on_event` and `remote.call`.
 
+Don't forget to read [the readme](readme.md) for information about using the Factorio Mod Debugger itself.
 
 
 If using tasks, you may want to use git-bash as your automation shell:


### PR DESCRIPTION
Creating a draft pull request as a means of inviting feedback.

I mention saving the emmylua docs in `.vscode`. This is opinionated. I think it's the right fit for the tutorial (I recall being confused where the hell I should put the file), but you might have a different default location/opinion here @ jarg, so please let me hear it. 

I think the general readme should mention the autocompletion support, despite it being more of a language server thing with this extension just helping out. Reasons:
1. It's a big feature :)
2. Makes it obvious that this extension enables it (currently hidden behind the knowledge of what emmylua docs are when looking at workspace.md).
3. Makes feature easy to find via search engine/the extension browser.
4. Something with a very clear name/heading to link to people when they ask for updates to `svizzini.factorio-lua-api-autocomplete`.
May be good to make sure generate typedefs works with sumneko 3.+ beforehand.

I'm unsure how much more on settings.json and launch.json should be in workspace.md. I picked up VSCode specifically to use the extension and struggled a lot at the start because the workspace setup skips launch.json and how to debug etc. This info is mostly in the readme, but at least my noob mind at that point expected all the "starting out" stuff to either be here or linked here.

I think workspace.md could have more details in general: what exactly do the extra generate typedefs prompts do, link to emmylua docs, how do I get to installing extensions, enable bracket colorizer, ya know, new to editor and its interface stuff. But that may bloat things a lot - possibly better as an extra document or video tutorial (don't need to explain to click a button in the sidebar when a video can show it). See also my TODOs :) 



