### PR TITLE
Fix extra '/doc' in link resulting in 404 error

### DIFF
--- a/doc/debugadapter.md
+++ b/doc/debugadapter.md
@@ -25,5 +25,5 @@ The debugger also injects runtime diagnostics into all hooked mods:
 
 ## Advanced Features
 
-  * [Debugger Mod API](doc/debugapi.md)
-  * [Custom Debug Views](doc/variables.md)
+  * [Debugger Mod API](debugapi.md)
+  * [Custom Debug Views](variables.md)


### PR DESCRIPTION
Document internal links have an extra '/doc' resulting in a 404 error.