### PR TITLE
Plugin ignore command context specifiers

### DIFF
--- a/sumneko-3rd/factorio/README.md
+++ b/sumneko-3rd/factorio/README.md
@@ -244,13 +244,17 @@ Any of the following at the start of a line will be removed by the plugin allowi
 - `/sc`
 - `/measured-command`
 
+The lua context specifier `__modname__` following any of the above is also removed when present.
+
 For example
 ```lua
 /c game.print("Hello world!")
 /sc game.speed = 10
+/c __my_mod__ game.print(serpent.block(global.foo))
 ```
 Would look something similar to this to the language server
 ```lua
 game.print("Hello world!")
 game.speed = 10
+game.print(serpent.block(global.foo))
 ```

--- a/sumneko-3rd/factorio/changelog.md
+++ b/sumneko-3rd/factorio/changelog.md
@@ -1,3 +1,6 @@
+### 2022-01-17
+- Improve support for `/command` by also removing the lua context specifier (`/command __modname__`) when present
+
 ### 2022-12-14
 - Add support for in game console commands in files by removing `/command` or any other variants at te start of a line
 

--- a/sumneko-3rd/factorio/factorio-plugin/command-line.lua
+++ b/sumneko-3rd/factorio/factorio-plugin/command-line.lua
@@ -17,6 +17,7 @@ local function replace(uri, text, diffs)
   for s_command, command, f_command in
     util.gmatch_at_start_of_line(text, "()/([a-z-]+%f[%s\0])()")--[[@as fun():integer, string, integer]]
   do
+    f_command = text:match("^ __[a-zA-Z0-9_-]+__()", f_command) or f_command
     if commands_lut[command] then
       util.add_diff(diffs, s_command, f_command, "")
     end


### PR DESCRIPTION
It's a greedy match to support mods with trailing `_`, not that that's all that important.

Aside from that I've updated the readme and changelog, though iirc you said they're not final as they are right now. But still, updated