### PR TITLE
Added support for passing environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -868,6 +868,13 @@
                 "default": [],
                 "description": "Extra command line arguments to pass to Factorio"
               },
+              "env": {
+                "type": "object",
+                "description": "Environment variables to pass to Factorio",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
               "adjustMods": {
                 "description": "Dictionary of modname -> true or version string to enable, false to disable",
                 "additionalProperties": {

--- a/src/Debug/FactorioProcess.ts
+++ b/src/Debug/FactorioProcess.ts
@@ -1,5 +1,5 @@
 
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, ChildProcess, SpawnOptions } from 'child_process';
 import { EventEmitter } from "events";
 import { BufferSplitter } from '../Util/BufferSplitter';
 import * as path from 'path';
@@ -16,17 +16,19 @@ export class FactorioProcess extends EventEmitter {
 	private readonly factorio: ChildProcess;
 	private readonly hasNativeDebug?: boolean;
 
-	constructor(factorioPath:string, factorioArgs:string[], nativeDebugger?:string) {
+	constructor(factorioPath:string, factorioArgs:string[], nativeDebugger?:string, env?:NodeJS.ProcessEnv) {
 		super();
+		let spawnOptions: SpawnOptions = {
+			cwd: path.dirname(factorioPath),
+			// applying passed environment variables over parent environment
+			env: Object.assign({}, process.env, env),
+		};
+
 		if (nativeDebugger) {
 			this.hasNativeDebug = true;
-			this.factorio = spawn(nativeDebugger, [factorioPath, ...factorioArgs], {
-				cwd: path.dirname(factorioPath),
-			});
+			this.factorio = spawn(nativeDebugger, [factorioPath, ...factorioArgs], spawnOptions);
 		} else {
-			this.factorio = spawn(factorioPath, factorioArgs, {
-				cwd: path.dirname(factorioPath),
-			});
+			this.factorio = spawn(factorioPath, factorioArgs, spawnOptions);
 		}
 		this.factorio.on("exit", (...args:any[])=>this.emit("exit", ...args));
 


### PR DESCRIPTION
Added launch configuration parameter `env` and passed it to `child_process.spawn()`

Feature was made for SDL_VIDEODRIVER var, e.g.:

```json
"configurations": [
    {
        "type": "factoriomod",
        "request": "launch",
        "name": "Factorio Mod Debug",
        "factorioArgs": ["--load-scenario", "test"],
        "env": {
            "SDL_VIDEODRIVER": "wayland,x11"
        }
    }
]
```