### PR TITLE
Fixed that params of util.*_safe were mandatory

### DIFF
--- a/sumneko-3rd/factorio/library/core/lualib/util.lua
+++ b/sumneko-3rd/factorio/library/core/lualib/util.lua
@@ -137,11 +137,11 @@ function util.conditional_return(value, data) end
 ---@return table
 function util.merge(tables) end
 
----@param entity LuaEntity
+---@param entity LuaEntity?
 ---@param item_dict ItemStackDefinition
 util.insert_safe = function(entity, item_dict) end
 
----@param entity LuaEntity
+---@param entity LuaEntity?
 ---@param item_dict ItemStackDefinition
 util.remove_safe = function(entity, item_dict) end
 

--- a/sumneko-3rd/factorio/library/core/lualib/util.lua
+++ b/sumneko-3rd/factorio/library/core/lualib/util.lua
@@ -138,11 +138,11 @@ function util.conditional_return(value, data) end
 function util.merge(tables) end
 
 ---@param entity LuaEntity?
----@param item_dict ItemStackDefinition
+---@param item_dict ItemStackDefinition?
 util.insert_safe = function(entity, item_dict) end
 
 ---@param entity LuaEntity?
----@param item_dict ItemStackDefinition
+---@param item_dict ItemStackDefinition?
 util.remove_safe = function(entity, item_dict) end
 
 ---@param string string


### PR DESCRIPTION
Both functions have a guard clause so their parameters are optional:
```lua
if not (entity and entity.valid and item_dict) then return end
``` 