### PR TITLE
Mention -p option in 'no prototype doc' sumneko-3rd error

### DIFF
--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -29,7 +29,7 @@ program.command("sumneko-3rd [outdir]")
 		};
 		if (docs.api_version === 4) {
 			if (!options.protos) {
-				console.log("prototype-api.json is required for v4 docs");
+				console.log("prototype-api.json (specified with -p arg) is required for v4 docs");
 				return;
 			}
 			pdocs = new ProtoDocGenerator((await fsp.readFile(options.protos, "utf8")).toString(), docsettings);


### PR DESCRIPTION
Not super happy with the wording, but better than nothing. Current error can be confusing if you are not aware of the `-p` option, like [here](https://discord.com/channels/139677590393716737/306402592265732098/1167003825731805206).
![image](https://github.com/justarandomgeek/vscode-factoriomod-debug/assets/27060268/95bfa51c-a6c8-4f99-b25e-42fb270771f7)

