### PR TITLE
Fix pluginArgs `--ignore` always erroring

### DIFF
--- a/luals-addon/factorio/plugin.lua
+++ b/luals-addon/factorio/plugin.lua
@@ -47,9 +47,9 @@ if not __plugin_dev then
       ignoring = true
     else
       if ignoring then
-        arg = workspace.getAbsolutePath(workspace_uti, arg)
+        arg = workspace.getAbsolutePath(workspace_uti, arg) -- Returns a normalized path.
         if arg then
-          ignored_paths[workspace.normalize(arg)] = true
+          ignored_paths[arg] = true
         end
       end
     end


### PR DESCRIPTION
It's been broken for a long time, but I didn't check in which version it got broken.
This is more so a little fix to lead up to the plugin args refactor and addition for plugin disabling. With that refactor would also come proper docs for pluginArgs.