### PR TITLE
Add plugin disabling part 1: `---@plugin` annotation

### DIFF
--- a/doc/language-lua.md
+++ b/doc/language-lua.md
@@ -32,6 +32,10 @@ The VS Code extension will automatically configure `"Lua.workspace.userThirdPart
 
 Because Factorio mods run in [several Lua VMs](https://lua-api.factorio.com/latest/auxiliary/data-lifecycle.html), some functions have cross-VM behavior that cannot be described fully with type definitions. We handle these by providing a plugin which transforms them into a more easily understood form before the Language Server sees them.
 
+### Plugin Disabling
+
+The plugin isn't perfect, so whenever it does something undesirable use `---@plugin ...` to disable it. It works very similar to `---@diagnostic`, for example: `---@plugin disable-line: on_event` or `---@plugin disable-next-line`.
+
 ### `require()`
 
 Factorio allows requiring files from another mod with a `__modname__` prefix:

--- a/luals-addon/factorio/factorio-plugin/command-line.lua
+++ b/luals-addon/factorio/factorio-plugin/command-line.lua
@@ -1,6 +1,7 @@
 --##
 
 local util = require("factorio-plugin.util")
+local command_line_module_flag = util.module_flags.command_line
 
 local commands_lut = {
   ["command"] = true,
@@ -14,11 +15,12 @@ local commands_lut = {
 ---@param text string @ The content of file
 ---@param diffs Diff[] @ The diffs to add more diffs to
 local function replace(uri, text, diffs)
+  util.reset_is_disabled_to_file_start()
   for s_command, command, f_command in
     util.gmatch_at_start_of_line(text, "()/([a-z-]+%f[%s\0])()")--[[@as fun():integer, string, integer]]
   do
     f_command = text:match("^ __[a-zA-Z0-9_-]+__()", f_command) or f_command
-    if commands_lut[command] then
+    if commands_lut[command] and not util.is_disabled(s_command, command_line_module_flag) then
       util.add_diff(diffs, s_command, f_command, "")
     end
   end

--- a/luals-addon/factorio/factorio-plugin/global.lua
+++ b/luals-addon/factorio/factorio-plugin/global.lua
@@ -1,6 +1,7 @@
 --##
 
 local util = require("factorio-plugin.util")
+local global_module_flag = util.module_flags.global
 local workspace
 if not __plugin_dev then
   workspace = require("workspace")
@@ -65,7 +66,7 @@ local function replace(uri, text, diffs)
     end
 
     local function add_diffs(start, finish, ignore_pos, ignore_char)
-      if matches_to_ignore[start] then return end
+      if matches_to_ignore[start] or util.is_disabled(start, global_module_flag) then return end
       local before = text:sub(start - 1, start - 1)
       if before ~= "" then
         -- Put the newline on a separate diff before the one replacing 'global',
@@ -82,6 +83,7 @@ local function replace(uri, text, diffs)
     -- There is duplication here, which would usually be handled by a util function,
     -- however since we are dealing with a variable amount of values, creating a generic
     -- function for it would be incredibly inefficient, constantly allocating new tables.
+    util.reset_is_disabled_to_file_start()
     for preceding_text, start, finish, ignore_pos, ignore_char, final_pos in
       util.gmatch_at_start_of_line(text, "([^\n]-)%f[a-zA-Z0-9_]()global()[^%S\n]*()([=.%[])()")--[[@as fun(): string, integer, integer, integer, string, integer]]
     do

--- a/luals-addon/factorio/factorio-plugin/object-name.lua
+++ b/luals-addon/factorio/factorio-plugin/object-name.lua
@@ -1,12 +1,14 @@
 --##
 
 local util = require("factorio-plugin.util")
+local object_name_module_flag = util.module_flags.object_name
 
 ---@param _ string @ The uri of file
 ---@param text string @ The content of file
 ---@param diffs Diff[] @ The diffs to add more diffs to
 local function replace(_, text, diffs)
   -- p_front is 1 after the front
+  util.reset_is_disabled_to_file_start()
   ---@type string, integer, integer, integer
   for preceding_text, p_front, p_dot, f_obj_name in
     util.gmatch_at_start_of_line(text, "([^\n]-)()[a-zA-Z_][a-zA-Z0-9_]*%s*()%.%s*object_name()%f[^a-zA-Z0-9_]")
@@ -14,6 +16,7 @@ local function replace(_, text, diffs)
     if preceding_text:find("--", 1, true)
       or preceding_text:find("%.%s*$")
       or preceding_text:find("function%s*$")
+      or util.is_disabled(p_front, object_name_module_flag)
     then
       goto continue
     end

--- a/luals-addon/factorio/factorio-plugin/on-event.lua
+++ b/luals-addon/factorio/factorio-plugin/on-event.lua
@@ -1,6 +1,7 @@
 --##
 
 local util = require("factorio-plugin.util")
+local on_event_module_flag = util.module_flags.on_event
 
 ---@param event_id_param string
 ---@return string|nil
@@ -22,11 +23,14 @@ local function replace(_, text, diffs)
   ---@param s_func_param integer
   ---@param class_name_getter fun(): string
   local function process_func_param(s_func_param, class_name_getter)
-    ---@type integer|nil, string, integer
-    local s_func, param_name, f_func = text:match("^%s*()function%s*%(%s*([^)%s]+)()", s_func_param)
+    ---@type integer|nil, integer, string, integer
+    local s_func, p_param_name, param_name, f_func = text:match("^%s*()function%s*%(%s*()([^)%s]+)()", s_func_param)
 
-    if s_func and not text:match("^[^\n]-%-%-##()", f_func) then
-    local class_name = class_name_getter()
+    if s_func
+      and not text:match("^[^\n]-%-%-##()", f_func)
+      and not util.is_disabled(p_param_name, on_event_module_flag)
+    then
+      local class_name = class_name_getter()
       if class_name then
         util.add_diff(diffs, s_func_param, s_func,
           "\n---@diagnostic disable-next-line:undefined-doc-name\n---@param "
@@ -66,6 +70,7 @@ local function replace(_, text, diffs)
     end
   end
 
+  util.reset_is_disabled_to_file_start()
   for preceding_text, s_param in
     util.gmatch_at_start_of_line(text, "([^\n]-)on_event%s*%(%s*()")--[[@as fun():string, integer]]
   do
@@ -74,6 +79,7 @@ local function replace(_, text, diffs)
     end
   end
 
+  util.reset_is_disabled_to_file_start()
   for preceding_text, s_param in
     util.gmatch_at_start_of_line(text, "([^\n]-)[Ee]vent%s*%.%s*register%s*%(%s*()")--[[@as fun():string, integer]]
   do
@@ -82,6 +88,7 @@ local function replace(_, text, diffs)
     end
   end
 
+  util.reset_is_disabled_to_file_start()
   for preceding_text, class_name, s_func_param in
     util.gmatch_at_start_of_line(text, "([^\n]-)[Ee]vent%s*%.%s*([a-zA-Z_][a-zA-Z0-9_]*)%s*%(()")--[[@as fun():string, string, integer]]
   do

--- a/luals-addon/factorio/factorio-plugin/on-event.lua
+++ b/luals-addon/factorio/factorio-plugin/on-event.lua
@@ -23,13 +23,9 @@ local function replace(_, text, diffs)
   ---@param s_func_param integer
   ---@param class_name_getter fun(): string
   local function process_func_param(s_func_param, class_name_getter)
-    ---@type integer|nil, integer, string, integer
-    local s_func, p_param_name, param_name, f_func = text:match("^%s*()function%s*%(%s*()([^)%s]+)()", s_func_param)
-
-    if s_func
-      and not text:match("^[^\n]-%-%-##()", f_func)
-      and not util.is_disabled(p_param_name, on_event_module_flag)
-    then
+    ---@type integer|nil, integer, string
+    local s_func, s_param_name, param_name = text:match("^%s*()function%s*%(%s*()([^)%s]+)", s_func_param)
+    if s_func and not util.is_disabled(s_param_name, on_event_module_flag) then
       local class_name = class_name_getter()
       if class_name then
         util.add_diff(diffs, s_func_param, s_func,

--- a/luals-addon/factorio/factorio-plugin/require.lua
+++ b/luals-addon/factorio/factorio-plugin/require.lua
@@ -1,15 +1,16 @@
 --##
 
 local util = require("factorio-plugin.util")
+local require_module_flag = util.module_flags.require
 
 ---@param _ string @ The uri of file
 ---@param text string @ The content of file
 ---@param diffs Diff[] @ The diffs to add more diffs to
 local function replace(_, text, diffs)
+  util.reset_is_disabled_to_file_start()
   for start, name, finish in
     text:gmatch("require%s*%(?%s*['\"]()(.-)()['\"]%s*%)?")--[=[@as fun(): integer, string, integer]=]
   do
-
     local original_name = name
 
     ---Convert the mod name prefix if there is one
@@ -25,7 +26,7 @@ local function replace(_, text, diffs)
       name = name:gsub("%.[^.\\/]+$", "")
     end
 
-    if name ~= original_name then
+    if name ~= original_name and not util.is_disabled(start, require_module_flag) then
       util.add_diff(diffs, start, finish, name)
     end
   end

--- a/luals-addon/factorio/plugin.lua
+++ b/luals-addon/factorio/plugin.lua
@@ -78,6 +78,8 @@ function OnSetText(uri, text)
 
   local diffs = {count = 0} ---@type Diff.ArrayWithCount
 
+  util.on_pre_process_file(text)
+
   require_module.replace(uri, text, diffs)
   remote.replace(uri, text, diffs)
   on_event.replace(uri, text, diffs)

--- a/luals-addon/factorio/plugin.lua
+++ b/luals-addon/factorio/plugin.lua
@@ -78,7 +78,7 @@ function OnSetText(uri, text)
 
   local diffs = {count = 0} ---@type Diff.ArrayWithCount
 
-  util.on_pre_process_file(text)
+  util.on_pre_process_file(text, diffs)
 
   require_module.replace(uri, text, diffs)
   remote.replace(uri, text, diffs)


### PR DESCRIPTION
Adds `---@plugin <tag>: <module_one>, <module_two>`
- `<tag>` is a bad name, but it's
  - `disable-next-line`
  - `disable-line`
  - `disable`
  - `enable`
- `<module_name>` is
  - `command_line`
  - `global`
  - `object_name`
  - `on_event`
  - `remote_add`
  - `remote_call`
  - `require`

Adds intellisense for both tags and module names.

The only question from me is your opinion on `remote_add` and `remote_call` being separated. My thought process is that people do weird things, so allowing them to just disable one of them (like add) in a file while still using call would be useful, and adding that separation was easy. But it's also easy to combine them.

(edit: damn it I keep forgetting to change the base branch)