### PR TITLE
Rewrite clusterio module requires

### DIFF
--- a/luals-addon/factorio/factorio-plugin/require.lua
+++ b/luals-addon/factorio/factorio-plugin/require.lua
@@ -19,8 +19,8 @@ local function replace(_, text, diffs)
     --- 'modules/plugin_name/', so the actual code needs to require("modules/plugin_name/file").
     --- Do a back substituion here for everything except modules/clusterio, as the clusterio repo 
     --- has its sources at 'packages/host/modules/clusterio/api.lua'.
-    if not name:find("modules/clusterio/") then
-        name = name:gsub("modules/[^\\/]-/", "module/")
+    if not name:find("^modules/clusterio/") then
+        name = name:gsub("^modules/[^\\/]-/", "module/")
     end
 
     ---If the path has slashes in it, it may also have an extension

--- a/luals-addon/factorio/factorio-plugin/require.lua
+++ b/luals-addon/factorio/factorio-plugin/require.lua
@@ -15,6 +15,13 @@ local function replace(_, text, diffs)
 
     ---Convert the mod name prefix if there is one
     name = name:gsub("^__(.-)__", "%1")
+    --- Clusterio modules are structured with their source in 'module/'. The loader rewrites this to
+    --- 'modules/plugin_name/', so the actual code needs to require("modules/plugin_name/file").
+    --- Do a back substituion here for everything except modules/clusterio, as the clusterio repo 
+    --- has its sources at 'packages/host/modules/clusterio/api.lua'.
+    if not name:find("modules/clusterio/") then
+        name = name:gsub("modules/[^\\/]-/", "module/")
+    end
 
     ---If the path has slashes in it, it may also have an extension
     ---the LS is not expecting. Factorio would also clobber any extension


### PR DESCRIPTION
Clusterio modules use a different convention [module paths](https://github.com/clusterio/clusterio/blob/master/docs/developing-for-clusterio.md#clusterio_api-library). This rewrites those paths so that the requires are correctly resolved.