### PR TITLE
Fix math.random description

### DIFF
--- a/luals-addon/factorio/library/lua/math.lua
+++ b/luals-addon/factorio/library/lua/math.lua
@@ -342,7 +342,7 @@ function math.ult(m, n) end
 ---This method can't be used outside of events or during loading. Calling it with non-integer arguments will floor them instead of resulting in an error.
 ---
 ---* `math.random()`: Returns a float in the range [0,1).
----* `math.random(n)`: Returns a integer in the range [1, n].
+---* `math.random(m)`: Returns a integer in the range [1, m].
 ---* `math.random(m, n)`: Returns a integer in the range [m, n].
 ---
 ---@overload fun():number


### PR DESCRIPTION
LuaLS doesn't seem to take the override for parameter names.

Either way, the 5.2 manual uses m for a single argument anyways
![Screenshot from 2024-07-12 12-43-03](https://github.com/user-attachments/assets/61f8832d-2d2b-4b6d-ad0f-bc259cd39c5a)

While the Factorio changes only references the seeding and when you can call it
![Screenshot from 2024-07-12 12-49-46](https://github.com/user-attachments/assets/194e84ae-e3f8-4494-81b6-6153bd9f3d32)
