### PR TITLE
Emit no error for empty changelog file

### DIFF
--- a/src/Language/ChangeLog.ts
+++ b/src/Language/ChangeLog.ts
@@ -169,6 +169,8 @@ export class ChangeLogLanguageService {
 				} else {
 					seenStartLast = false;
 				}
+			} else if (changelog.length == 1 && line == "") {
+				// empty file is not an error, wait for some content before annotating a problem
 			} else {
 				diags.push({
 					message: "Line not in valid block",


### PR DESCRIPTION
Currently an empty changelog file produces an error "Line not in valid block" which I don't think is appropriate.