### PR TITLE
Allow resolution of clusterio module exports

### DIFF
--- a/luals-addon/factorio/factorio-plugin/require.lua
+++ b/luals-addon/factorio/factorio-plugin/require.lua
@@ -17,12 +17,18 @@ local function replace(_, text, diffs, args)
     ---Convert the mod name prefix if there is one
     name = name:gsub("^__(.-)__", "%1")
 
-    --- Clusterio modules are structured with their source in 'module/'. The loader rewrites this to
-    --- 'modules/plugin_name/', so the actual code needs to require("modules/plugin_name/file").
-    --- Do a back substitution here for everything except modules/clusterio, as the clusterio repo
+    --- Clusterio modules are structured with their source in 'plugin_name/module/'.
+    --- The loader rewrites this to 'modules/plugin_name/', so it appears as 'require("modules/plugin_name/file")'.
+    --- The loader also creates the file 'modules/plugin_name.lua' from 'plugin_name/module/module_exports.lua'
+    --- Do a back substitution of both changes for all paths except modules/clusterio, as the clusterio repo
     --- has its sources at 'packages/host/modules/clusterio/api.lua'.
     if args.clusterio_modules and not name:find("^modules/clusterio/") then
-      name = name:gsub("^modules/[^/]-/", "module/")
+      if name:find("^modules/[^/]-$") then
+        -- 'modules/plugin_name' -> 'modules/plugin_name/module_exports'
+        name = name .. "/module_exports"
+      end
+      -- 'modules/plugin_name/path/to/file' -> 'plugin_name/module/path/to/file'
+      name = name:gsub("^modules/([^/]-)/", "%1/module/")
     end
 
     ---If the path has slashes in it, it may also have an extension


### PR DESCRIPTION
Updates the require resolution logic when the clusterio option is enabled.
1) The clusterio loader now creates the file `modules/plugin_name.lua` if the plugin contains a `module_exports.lua` file in it's source. Therefore any require paths of the form `^modules/plugin_name$` should resolve to `plugin_name/module/module_exports.lua`. Change: This new logic was added.
2) There is the assumption that the workspace of vscode is `external_plugins` when working on plugins, similar to how mod development assumes the workspace is `mods`. The previous logic discarded the plugin name which could cause multiple files to be resolved for a single path. e.g. `modules/plugin_a/foo` would resolve to both `plugin_a/module/foo.lua` and `plugin_b/module/foo.lua` which was particularly noticeable for module exports. Change: the plugin name is no longer discarded.