### PR TITLE
Fix missing inheritance of LuaObject from userdata

### DIFF
--- a/luals-addon/factorio/library/runtime/LuaObject.lua
+++ b/luals-addon/factorio/library/runtime/LuaObject.lua
@@ -5,6 +5,6 @@
 ---@nodiscard
 function __object_name(object) end
 
----@class LuaObject
+---@class LuaObject: userdata
 ---@field valid boolean
 ---@field object_name LuaObject.object_name


### PR DESCRIPTION
All LuaObjects are userdata primative types, therefore they must inherit from userdata in order for certain type assertions and type narrowings to work correctly.

Fixes #165 