### PR TITLE
Add sound-util.lua to the library

### DIFF
--- a/luals-addon/factorio/library/core/lualib/event_handler.lua
+++ b/luals-addon/factorio/library/core/lualib/event_handler.lua
@@ -1,4 +1,4 @@
----@meta _
+---@meta
 
 ---@class event_handler
 ---@field events? event_handler.events

--- a/luals-addon/factorio/library/core/lualib/sound-util.lua
+++ b/luals-addon/factorio/library/core/lualib/sound-util.lua
@@ -1,4 +1,4 @@
----@meta sound-util
+---@meta
 
 ---Will create a list of sound definitions.
 ---

--- a/luals-addon/factorio/library/core/lualib/sound-util.lua
+++ b/luals-addon/factorio/library/core/lualib/sound-util.lua
@@ -1,0 +1,27 @@
+---@meta sound-util
+
+---Will create a list of sound definitions.
+---
+---Uses the filename pattern of `"filepath".."-"..K..".ogg"` where K is the variation number.
+---@param filename_string string
+---@param variations integer
+---@param volume_parameter? float
+---@param modifiers_parameter? data.SoundModifier[]|data.SoundModifier
+---@return data.SoundDefinition[]
+function sound_variations(filename_string, variations, volume_parameter, modifiers_parameter) end
+
+---Will create a list of sound definitions with volume variations.
+---
+---Uses the filename pattern of `"filepath".."-"..K..".ogg"` where K is the variation number.
+---@param filename_string string
+---@param variations integer
+---@param min_volume? float
+---@param max_volume? float
+---@param modifiers_parameter? data.SoundModifier[]|data.SoundModifier
+---@return data.SoundDefinition[]
+function sound_variations_with_volume_variations(filename_string, variations, min_volume, max_volume, modifiers_parameter) end
+
+---@param type_parameter data.SoundModifierType
+---@param volume_multiplier_parameter float
+---@return data.SoundModifier
+function volume_multiplier(type_parameter, volume_multiplier_parameter) end


### PR DESCRIPTION
I'm not convinced of the description of the filename pattern, but I can't currently think of a better way of describing it.

I also took the time to remove `_` from the event_handler meta, because it's always bothered me that requiring the file doesn't correctly type the returned object.