### PR TITLE
Fix plugin storage if previous line is a comment ending with a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Add missing locale for Restart Session control
 * LuaLS library package:
   * Fix incorrectly generating types `data.number` and `data.table` in prototype docs
+  * Fix comments ending with a dot on the line before `storage` making the plugin not transform it into the mod specific `storage`
 
 ## 2.0.7
 * VSCode:

--- a/luals-addon/factorio/factorio-plugin/storage.lua
+++ b/luals-addon/factorio/factorio-plugin/storage.lua
@@ -75,7 +75,8 @@ local function replace(uri, text, diffs)
       local start = finish - #"storage"
       if identifier_char_lut[text:sub(start - 1, start - 1)] then goto continue end
 
-      local preceding_start = start - 16
+      -- Negative indexes would make it start at the back of the string. No no, very bad.
+      local preceding_start = math.max(1, start - 16)
       local preceding_text = text:sub(preceding_start, start - 1)
       local dot_pos = preceding_text:match("()%.%s*$")
       if dot_pos then

--- a/luals-addon/factorio/factorio-plugin/storage.lua
+++ b/luals-addon/factorio/factorio-plugin/storage.lua
@@ -80,7 +80,8 @@ local function replace(uri, text, diffs)
       local dot_pos = preceding_text:match("()%.%s*$")
       if dot_pos then
         dot_pos = preceding_start + dot_pos - 1
-        if text:sub(dot_pos - 1, dot_pos - 1) ~= "." -- If it's a concat, keep it.
+        if not util.is_disabled(dot_pos, storage_module_flag)
+          and text:sub(dot_pos - 1, dot_pos - 1) ~= "." -- If it's a concat, keep it.
           and text:sub(dot_pos - 2, dot_pos - 1) ~= "_G" -- Keep indexes into _G
           and text:sub(dot_pos - 4, dot_pos - 1) ~= "_ENV" -- and _ENV
         then


### PR DESCRIPTION
In this example
```lua
-- Hello World.
storage.foo = 100
```
The plugin would ignore this `storage` because there is a `World.` before it so it thought `storage` was a key being used to index something. But that's commented out, so this PR fixes that issue.