### PR TITLE
Fix `==` being accepted in dependencies and improve error message

### DIFF
--- a/schema/datainfo.json
+++ b/schema/datainfo.json
@@ -52,6 +52,7 @@
       "items": {
         "type":"string",
         "pattern": "^(([!?~+]|\\(\\?\\)) *)?([a-zA-Z0-9_ -]+)( *([<>]=?|=) *((\\d+\\.){1,2}\\d+))?$",
+        "errorMessage": "Dependency does not match pattern \"[?|(?)|!|~|+] ModName [EqualityOperator ModVersion]\"",
         "defaultSnippets": [
           {
             "label": "simple",
@@ -59,7 +60,7 @@
           },
           {
             "label": "version",
-            "body": "${1:modname} ${2|<,<=,>,>=,==|} ${3:0.0.0}"
+            "body": "${1:modname} ${2|<,<=,>,>=,=|} ${3:0.0.0}"
           },
           {
             "label": "incompatible",
@@ -83,11 +84,11 @@
           },
           {
             "label": "version",
-            "body": "${1:modname} ${2|<,<=,>,>=,==|} ${3:0.0.0}"
+            "body": "${1:modname} ${2|<,<=,>,>=,=|} ${3:0.0.0}"
           },
           {
             "label": "full",
-            "body": "${1| ,~,?,(?)|} ${2:modname} ${3|<,<=,>,>=,==|} ${4:0.0.0}"
+            "body": "${1| ,~,?,(?),+|} ${2:modname} ${3|<,<=,>,>=,=|} ${4:0.0.0}"
           }
         ]
       }


### PR DESCRIPTION
The error message is specifically `Dependency does not match pattern "[?|(?)|!|~] ModName [EqualityOperator ModVersion]`
This message will apply when the given type is incorrect, but I think that doesn't matter that much.

Here's a couple examples.
<img width="975" height="112" alt="image" src="https://github.com/user-attachments/assets/f114f13d-869c-4af2-9278-eb074c46b1a6" />
<img width="850" height="103" alt="image" src="https://github.com/user-attachments/assets/219628eb-221f-4957-8c0c-8664a7f8fb14" />
<img width="972" height="102" alt="image" src="https://github.com/user-attachments/assets/ed2c498c-0ebc-49ea-bb06-d39abf0b2cb8" />

All the same error, wildly different "mistakes"