### PR TITLE
Add `prototype-info.lua`

### DIFF
--- a/luals-addon/factorio/library/core/lualib/prototype-info.lua
+++ b/luals-addon/factorio/library/core/lualib/prototype-info.lua
@@ -1,0 +1,20 @@
+---@meta
+---@namespace lualib
+
+---@class PrototypeInfo
+---@field base_type keyof defines.prototypes
+--- The types that directly inherit from this type, includes abstract types
+---@field children (string)[]
+--- The non-abstract types that qualify for this type.
+---
+--- eg: `"item"` has entries like `"item"`, `"item-with-label"`, `"item-with-inventory"`, `"blueprint-book"`, and so on.
+---@field types (keyof data.raw)[]
+--- Whether or not the this type is abstract.
+---@field abstract? true
+--- The type this one inherits from, if there is one.
+---@field parent? string
+
+---@type table<string,PrototypeInfo>
+local info
+
+return info

--- a/src/vscode/VersionSelector.ts
+++ b/src/vscode/VersionSelector.ts
@@ -625,6 +625,7 @@ export class FactorioVersionSelector {
 						"core/lualib/util.lua",
 						"core/lualib/silo-script.lua",
 						"core/lualib/space-finish-script.lua",
+						"core/lualib/prototype-info.lua",
 						"base/scripts/freeplay/",
 						"base/scripts/pvp/",
 						"base/scripts/sandbox/",


### PR DESCRIPTION
Simple enough file I don't have to waffle over if it's good enough. If you can think of a description for `base_type` I'd take it. I couldn't think of a concise one and I feel like it's self explanatory to the people who are going to be touching this type anyways.

If you come to a decision about namespaces and lualib, it should be easy enough to change. I will still personally vote for all lualib files having `lualib`.